### PR TITLE
[임지영] 2-1단계 - 리다이렉트 필터,  2-2단계 - Oauth 인증 필터

### DIFF
--- a/src/main/java/nextstep/app/InMemoryClientRegistrationRepository.java
+++ b/src/main/java/nextstep/app/InMemoryClientRegistrationRepository.java
@@ -1,24 +1,26 @@
 package nextstep.app;
 
 import jakarta.annotation.Nullable;
+import nextstep.security.oauth2.ClientRegistration;
 import nextstep.security.properties.ClientRegistrationRepository;
 import nextstep.security.properties.OAuth2ClientProperties;
-import nextstep.security.properties.Registration;
 import org.springframework.stereotype.Component;
+
+import java.util.Map;
 
 @Component
 public class InMemoryClientRegistrationRepository implements ClientRegistrationRepository {
 
-    private final OAuth2ClientProperties oAuth2ClientProperties;
+    private final Map<String, ClientRegistration> registrations;
 
     public InMemoryClientRegistrationRepository(final OAuth2ClientProperties oAuth2ClientProperties) {
-        this.oAuth2ClientProperties = oAuth2ClientProperties;
+        this.registrations = ClientRegistration.from(oAuth2ClientProperties);
     }
 
     @Override
     @Nullable
-    public Registration findRegistrationById(final String id) {
-        return oAuth2ClientProperties.getRegistration(id);
+    public ClientRegistration findRegistrationById(final String id) {
+        return registrations.get(id);
     }
 
 }

--- a/src/main/java/nextstep/app/InMemoryClientRegistrationRepository.java
+++ b/src/main/java/nextstep/app/InMemoryClientRegistrationRepository.java
@@ -2,23 +2,23 @@ package nextstep.app;
 
 import jakarta.annotation.Nullable;
 import nextstep.security.properties.ClientRegistrationRepository;
-import nextstep.security.properties.OAuth2Properties;
+import nextstep.security.properties.OAuth2ClientProperties;
 import nextstep.security.properties.Registration;
 import org.springframework.stereotype.Component;
 
 @Component
 public class InMemoryClientRegistrationRepository implements ClientRegistrationRepository {
 
-    private final OAuth2Properties oAuth2Properties;
+    private final OAuth2ClientProperties oAuth2ClientProperties;
 
-    public InMemoryClientRegistrationRepository(final OAuth2Properties oAuth2Properties) {
-        this.oAuth2Properties = oAuth2Properties;
+    public InMemoryClientRegistrationRepository(final OAuth2ClientProperties oAuth2ClientProperties) {
+        this.oAuth2ClientProperties = oAuth2ClientProperties;
     }
 
     @Override
     @Nullable
     public Registration findRegistrationById(final String id) {
-        return oAuth2Properties.getRegistration(id);
+        return oAuth2ClientProperties.getRegistration(id);
     }
 
 }

--- a/src/main/java/nextstep/app/SecurityApplication.java
+++ b/src/main/java/nextstep/app/SecurityApplication.java
@@ -1,13 +1,13 @@
 package nextstep.app;
 
-import nextstep.security.properties.OAuth2Properties;
+import nextstep.security.properties.OAuth2ClientProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 
 @SpringBootApplication
-@EnableConfigurationProperties(OAuth2Properties.class)
+@EnableConfigurationProperties(OAuth2ClientProperties.class)
 public class SecurityApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/nextstep/app/SecurityConfig.java
+++ b/src/main/java/nextstep/app/SecurityConfig.java
@@ -75,10 +75,10 @@ public class SecurityConfig {
                 new OAuth2AuthorizationRequestRedirectFilter(
                         oAuth2AuthorizationRequestResolver(clientRegistrationRepository),
                         authorizationRequestRepository()),
-                new OAuth2AuthenticationFilter(
-                        clientRegistrationRepository,
+                new OAuth2LoginAuthenticationFilter(
                         oAuth2AuthenticationSuccessHandler(),
-                        oAuth2UserDetailsServices),
+                        oAuth2UserDetailsServices,
+                        authorizationRequestRepository()),
                 new AuthorizationFilter(requestAuthorizationManager())));
     }
 

--- a/src/main/java/nextstep/app/SecurityConfig.java
+++ b/src/main/java/nextstep/app/SecurityConfig.java
@@ -21,7 +21,7 @@ import nextstep.security.context.HttpSessionSecurityContextRepository;
 import nextstep.security.context.SecurityContextHolderFilter;
 import nextstep.security.oauth2.OAuth2AuthenticationFilter;
 import nextstep.security.oauth2.OAuth2AuthenticationSuccessHandler;
-import nextstep.security.oauth2.OAuth2RedirectFilter;
+import nextstep.security.oauth2.OAuth2AuthorizationRequestRedirectFilter;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetailsService;
 import nextstep.security.properties.ClientRegistrationRepository;
 import nextstep.security.userdetails.UserDetails;
@@ -74,7 +74,7 @@ public class SecurityConfig {
         return new DefaultSecurityFilterChain(List.of(new SecurityContextHolderFilter(httpSessionSecurityContextRepository()),
                 new UsernamePasswordAuthenticationFilter(userDetailsService()),
                 new BasicAuthenticationFilter(userDetailsService()),
-                new OAuth2RedirectFilter(clientRegistrationRepository),
+                new OAuth2AuthorizationRequestRedirectFilter(clientRegistrationRepository),
                 new OAuth2AuthenticationFilter(
                         clientRegistrationRepository,
                         oAuth2AuthenticationSuccessHandler(),

--- a/src/main/java/nextstep/app/SecurityConfig.java
+++ b/src/main/java/nextstep/app/SecurityConfig.java
@@ -10,6 +10,7 @@ import nextstep.security.access.RequestMatcherEntry;
 import nextstep.security.access.hierarchicalroles.RoleHierarchy;
 import nextstep.security.access.hierarchicalroles.RoleHierarchyImpl;
 import nextstep.security.authentication.AuthenticationException;
+import nextstep.security.authentication.AuthenticationManager;
 import nextstep.security.authentication.BasicAuthenticationFilter;
 import nextstep.security.authentication.UsernamePasswordAuthenticationFilter;
 import nextstep.security.authorization.*;
@@ -20,6 +21,7 @@ import nextstep.security.config.SecurityFilterChain;
 import nextstep.security.context.HttpSessionSecurityContextRepository;
 import nextstep.security.context.SecurityContextHolderFilter;
 import nextstep.security.oauth2.*;
+import nextstep.security.oauth2.login.OAuth2LoginAuthenticationProvider;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetailsService;
 import nextstep.security.properties.ClientRegistrationRepository;
 import nextstep.security.userdetails.UserDetails;
@@ -77,8 +79,8 @@ public class SecurityConfig {
                         authorizationRequestRepository()),
                 new OAuth2LoginAuthenticationFilter(
                         oAuth2AuthenticationSuccessHandler(),
-                        oAuth2UserDetailsServices,
-                        authorizationRequestRepository()),
+                        authorizationRequestRepository(),
+                        oAuth2LoginAuthenticationProvider()),
                 new AuthorizationFilter(requestAuthorizationManager())));
     }
 
@@ -142,4 +144,9 @@ public class SecurityConfig {
     public AuthorizationRequestRepository authorizationRequestRepository() {
         return new AuthorizationRequestRepository();
     }
+
+    public AuthenticationManager oAuth2LoginAuthenticationProvider() {
+        return new OAuth2LoginAuthenticationProvider(oAuth2UserDetailsServices);
+    }
+
 }

--- a/src/main/java/nextstep/app/SecurityConfig.java
+++ b/src/main/java/nextstep/app/SecurityConfig.java
@@ -3,16 +3,13 @@ package nextstep.app;
 import nextstep.app.application.MemberService;
 import nextstep.app.domain.Member;
 import nextstep.app.domain.MemberRepository;
-import nextstep.app.oauth2.OAuth2AuthenticationSuccessHandlerImpl;
+import nextstep.app.oauth2.OAuth2AuthenticationSuccessHandler;
 import nextstep.security.access.AnyRequestMatcher;
 import nextstep.security.access.MvcRequestMatcher;
 import nextstep.security.access.RequestMatcherEntry;
 import nextstep.security.access.hierarchicalroles.RoleHierarchy;
 import nextstep.security.access.hierarchicalroles.RoleHierarchyImpl;
-import nextstep.security.authentication.AuthenticationException;
-import nextstep.security.authentication.AuthenticationManager;
-import nextstep.security.authentication.BasicAuthenticationFilter;
-import nextstep.security.authentication.UsernamePasswordAuthenticationFilter;
+import nextstep.security.authentication.*;
 import nextstep.security.authorization.*;
 import nextstep.security.config.DefaultSecurityFilterChain;
 import nextstep.security.config.DelegatingFilterProxy;
@@ -72,7 +69,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain() {
         return new DefaultSecurityFilterChain(List.of(new SecurityContextHolderFilter(httpSessionSecurityContextRepository()),
-                new UsernamePasswordAuthenticationFilter(userDetailsService()),
+                new UsernamePasswordAuthenticationFilter(userDetailsService(), new UsernamePasswordAuthenticationSuccessHandler()),
                 new BasicAuthenticationFilter(userDetailsService()),
                 new OAuth2AuthorizationRequestRedirectFilter(
                         oAuth2AuthorizationRequestResolver(clientRegistrationRepository),
@@ -129,8 +126,8 @@ public class SecurityConfig {
     }
 
     @Bean
-    public OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler() {
-        return new OAuth2AuthenticationSuccessHandlerImpl(
+    public AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler() {
+        return new OAuth2AuthenticationSuccessHandler(
                 httpSessionSecurityContextRepository(),
                 memberService);
     }

--- a/src/main/java/nextstep/app/SecurityConfig.java
+++ b/src/main/java/nextstep/app/SecurityConfig.java
@@ -4,6 +4,7 @@ import nextstep.app.application.MemberService;
 import nextstep.app.domain.Member;
 import nextstep.app.domain.MemberRepository;
 import nextstep.app.oauth2.OAuth2AuthenticationSuccessHandler;
+import nextstep.security.access.AntRequestMatcher;
 import nextstep.security.access.AnyRequestMatcher;
 import nextstep.security.access.MvcRequestMatcher;
 import nextstep.security.access.RequestMatcherEntry;
@@ -72,6 +73,7 @@ public class SecurityConfig {
                 new UsernamePasswordAuthenticationFilter(userDetailsService(), new UsernamePasswordAuthenticationSuccessHandler()),
                 new BasicAuthenticationFilter(userDetailsService()),
                 new OAuth2AuthorizationRequestRedirectFilter(
+                        new AntRequestMatcher(HttpMethod.GET, "/oauth2/authorization/**"),
                         oAuth2AuthorizationRequestResolver(clientRegistrationRepository),
                         authorizationRequestRepository()),
                 new OAuth2LoginAuthenticationFilter(

--- a/src/main/java/nextstep/app/SecurityConfig.java
+++ b/src/main/java/nextstep/app/SecurityConfig.java
@@ -145,7 +145,8 @@ public class SecurityConfig {
     }
 
     public AuthenticationManager oAuth2LoginAuthenticationProvider() {
-        return new OAuth2LoginAuthenticationProvider(oAuth2UserDetailsServices);
+        return new ProviderManager(List.of(
+                new OAuth2LoginAuthenticationProvider(oAuth2UserDetailsServices)));
     }
 
 }

--- a/src/main/java/nextstep/app/SecurityConfig.java
+++ b/src/main/java/nextstep/app/SecurityConfig.java
@@ -19,10 +19,7 @@ import nextstep.security.config.FilterChainProxy;
 import nextstep.security.config.SecurityFilterChain;
 import nextstep.security.context.HttpSessionSecurityContextRepository;
 import nextstep.security.context.SecurityContextHolderFilter;
-import nextstep.security.oauth2.OAuth2AuthenticationFilter;
-import nextstep.security.oauth2.OAuth2AuthenticationSuccessHandler;
-import nextstep.security.oauth2.OAuth2AuthorizationRequestRedirectFilter;
-import nextstep.security.oauth2.OAuth2AuthorizationRequestResolver;
+import nextstep.security.oauth2.*;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetailsService;
 import nextstep.security.properties.ClientRegistrationRepository;
 import nextstep.security.userdetails.UserDetails;
@@ -75,7 +72,9 @@ public class SecurityConfig {
         return new DefaultSecurityFilterChain(List.of(new SecurityContextHolderFilter(httpSessionSecurityContextRepository()),
                 new UsernamePasswordAuthenticationFilter(userDetailsService()),
                 new BasicAuthenticationFilter(userDetailsService()),
-                new OAuth2AuthorizationRequestRedirectFilter(oAuth2AuthorizationRequestResolver(clientRegistrationRepository)),
+                new OAuth2AuthorizationRequestRedirectFilter(
+                        oAuth2AuthorizationRequestResolver(clientRegistrationRepository),
+                        authorizationRequestRepository()),
                 new OAuth2AuthenticationFilter(
                         clientRegistrationRepository,
                         oAuth2AuthenticationSuccessHandler(),
@@ -137,5 +136,10 @@ public class SecurityConfig {
     @Bean
     public OAuth2AuthorizationRequestResolver oAuth2AuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
         return new OAuth2AuthorizationRequestResolver(clientRegistrationRepository);
+    }
+
+    @Bean
+    public AuthorizationRequestRepository authorizationRequestRepository() {
+        return new AuthorizationRequestRepository();
     }
 }

--- a/src/main/java/nextstep/app/SecurityConfig.java
+++ b/src/main/java/nextstep/app/SecurityConfig.java
@@ -22,6 +22,7 @@ import nextstep.security.context.SecurityContextHolderFilter;
 import nextstep.security.oauth2.OAuth2AuthenticationFilter;
 import nextstep.security.oauth2.OAuth2AuthenticationSuccessHandler;
 import nextstep.security.oauth2.OAuth2AuthorizationRequestRedirectFilter;
+import nextstep.security.oauth2.OAuth2AuthorizationRequestResolver;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetailsService;
 import nextstep.security.properties.ClientRegistrationRepository;
 import nextstep.security.userdetails.UserDetails;
@@ -74,7 +75,7 @@ public class SecurityConfig {
         return new DefaultSecurityFilterChain(List.of(new SecurityContextHolderFilter(httpSessionSecurityContextRepository()),
                 new UsernamePasswordAuthenticationFilter(userDetailsService()),
                 new BasicAuthenticationFilter(userDetailsService()),
-                new OAuth2AuthorizationRequestRedirectFilter(clientRegistrationRepository),
+                new OAuth2AuthorizationRequestRedirectFilter(oAuth2AuthorizationRequestResolver(clientRegistrationRepository)),
                 new OAuth2AuthenticationFilter(
                         clientRegistrationRepository,
                         oAuth2AuthenticationSuccessHandler(),
@@ -131,5 +132,10 @@ public class SecurityConfig {
         return new OAuth2AuthenticationSuccessHandlerImpl(
                 httpSessionSecurityContextRepository(),
                 memberService);
+    }
+
+    @Bean
+    public OAuth2AuthorizationRequestResolver oAuth2AuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+        return new OAuth2AuthorizationRequestResolver(clientRegistrationRepository);
     }
 }

--- a/src/main/java/nextstep/app/oauth2/GithubOAuth2UserDetailService.java
+++ b/src/main/java/nextstep/app/oauth2/GithubOAuth2UserDetailService.java
@@ -2,7 +2,7 @@ package nextstep.app.oauth2;
 
 import nextstep.security.oauth2.userdetails.AbstractOAuth2UserDetailsService;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetails;
-import org.springframework.beans.factory.annotation.Value;
+import nextstep.security.properties.ClientRegistrationRepository;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -10,12 +10,9 @@ import java.util.Set;
 
 @Component
 public class GithubOAuth2UserDetailService extends AbstractOAuth2UserDetailsService {
-    private final String userUrl;
 
-    public GithubOAuth2UserDetailService(
-            @Value("${app.oauth2.github.user-url}") final String userUrl
-    ) {
-        this.userUrl = userUrl;
+    public GithubOAuth2UserDetailService(final ClientRegistrationRepository clientRegistrationRepository) {
+        super(clientRegistrationRepository);
     }
 
     @Override
@@ -27,11 +24,6 @@ public class GithubOAuth2UserDetailService extends AbstractOAuth2UserDetailsServ
         return new OAuth2UserDetailsImpl(email, Map.of("name", name,
                 "avatarUrl", avatarUrl),
                 Set.of("USER"));
-    }
-
-    @Override
-    protected String getUserUrl() {
-        return this.userUrl;
     }
 
     @Override

--- a/src/main/java/nextstep/app/oauth2/GithubOAuth2UserDetailService.java
+++ b/src/main/java/nextstep/app/oauth2/GithubOAuth2UserDetailService.java
@@ -35,7 +35,7 @@ public class GithubOAuth2UserDetailService extends AbstractOAuth2UserDetailsServ
     }
 
     @Override
-    public String getVendor() {
+    public String getRegistrationId() {
         return "github";
     }
 }

--- a/src/main/java/nextstep/app/oauth2/GoogleOAuth2UserDetailService.java
+++ b/src/main/java/nextstep/app/oauth2/GoogleOAuth2UserDetailService.java
@@ -32,7 +32,7 @@ public class GoogleOAuth2UserDetailService extends AbstractOAuth2UserDetailsServ
     }
 
     @Override
-    public String getVendor() {
+    public String getRegistrationId() {
         return "google";
     }
 }

--- a/src/main/java/nextstep/app/oauth2/GoogleOAuth2UserDetailService.java
+++ b/src/main/java/nextstep/app/oauth2/GoogleOAuth2UserDetailService.java
@@ -2,7 +2,7 @@ package nextstep.app.oauth2;
 
 import nextstep.security.oauth2.userdetails.AbstractOAuth2UserDetailsService;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetails;
-import org.springframework.beans.factory.annotation.Value;
+import nextstep.security.properties.ClientRegistrationRepository;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -10,10 +10,9 @@ import java.util.Set;
 
 @Component
 public class GoogleOAuth2UserDetailService extends AbstractOAuth2UserDetailsService {
-    private final String userUrl;
 
-    public GoogleOAuth2UserDetailService(@Value("${app.oauth2.google.user-url}") final String userUrl) {
-        this.userUrl = userUrl;
+    public GoogleOAuth2UserDetailService(final ClientRegistrationRepository clientRegistrationRepository) {
+        super(clientRegistrationRepository);
     }
 
     @Override
@@ -26,10 +25,6 @@ public class GoogleOAuth2UserDetailService extends AbstractOAuth2UserDetailsServ
 
     }
 
-    @Override
-    protected String getUserUrl() {
-        return this.userUrl;
-    }
 
     @Override
     public String getRegistrationId() {

--- a/src/main/java/nextstep/app/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/nextstep/app/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -8,17 +8,17 @@ import nextstep.security.authentication.Authentication;
 import nextstep.security.context.HttpSessionSecurityContextRepository;
 import nextstep.security.context.SecurityContext;
 import nextstep.security.context.SecurityContextHolder;
-import nextstep.security.oauth2.OAuth2AuthenticationSuccessHandler;
+import nextstep.security.oauth2.AuthenticationSuccessHandler;
 import nextstep.security.oauth2.login.OAuth2LoginAuthenticationToken;
 
 import java.io.IOException;
 
-public class OAuth2AuthenticationSuccessHandlerImpl implements OAuth2AuthenticationSuccessHandler {
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
     private final HttpSessionSecurityContextRepository securityContextRepository;
     private final MemberService memberService;
 
-    public OAuth2AuthenticationSuccessHandlerImpl(final HttpSessionSecurityContextRepository securityContextRepository,
-                                                  final MemberService memberService) {
+    public OAuth2AuthenticationSuccessHandler(final HttpSessionSecurityContextRepository securityContextRepository,
+                                              final MemberService memberService) {
         this.securityContextRepository = securityContextRepository;
         this.memberService = memberService;
     }

--- a/src/main/java/nextstep/app/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/nextstep/app/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -8,7 +8,7 @@ import nextstep.security.authentication.Authentication;
 import nextstep.security.context.HttpSessionSecurityContextRepository;
 import nextstep.security.context.SecurityContext;
 import nextstep.security.context.SecurityContextHolder;
-import nextstep.security.oauth2.AuthenticationSuccessHandler;
+import nextstep.security.authentication.AuthenticationSuccessHandler;
 import nextstep.security.oauth2.login.OAuth2LoginAuthenticationToken;
 
 import java.io.IOException;

--- a/src/main/java/nextstep/app/oauth2/OAuth2AuthenticationSuccessHandlerImpl.java
+++ b/src/main/java/nextstep/app/oauth2/OAuth2AuthenticationSuccessHandlerImpl.java
@@ -5,13 +5,14 @@ import jakarta.servlet.http.HttpServletResponse;
 import nextstep.app.application.MemberService;
 import nextstep.app.payload.Oauth2MemberSaveDto;
 import nextstep.security.authentication.Authentication;
-import nextstep.security.authentication.OAuth2UserDetailsAuthenticationToken;
 import nextstep.security.context.HttpSessionSecurityContextRepository;
 import nextstep.security.context.SecurityContext;
 import nextstep.security.context.SecurityContextHolder;
 import nextstep.security.oauth2.OAuth2AuthenticationSuccessHandler;
+import nextstep.security.oauth2.login.OAuth2LoginAuthenticationToken;
 
 import java.io.IOException;
+
 public class OAuth2AuthenticationSuccessHandlerImpl implements OAuth2AuthenticationSuccessHandler {
     private final HttpSessionSecurityContextRepository securityContextRepository;
     private final MemberService memberService;
@@ -24,10 +25,10 @@ public class OAuth2AuthenticationSuccessHandlerImpl implements OAuth2Authenticat
 
     @Override
     public void onSuccess(final HttpServletRequest request, final HttpServletResponse response, final Authentication authentication) throws IOException {
-        if (authentication instanceof OAuth2UserDetailsAuthenticationToken authToken) {
-            var otherDetails = authToken.getOAuth2OtherDetails();
+        if (authentication instanceof OAuth2LoginAuthenticationToken authToken) {
+            var otherDetails = authToken.getOAuth2UserDetails().getOthers();
             memberService.saveOauth2Member(new Oauth2MemberSaveDto(
-                    (String) authToken.getPrincipal(),
+                    authToken.getPrincipal(),
                     otherDetails.get("name"),
                     otherDetails.get("avatar_url")
             ));

--- a/src/main/java/nextstep/security/authentication/AbstractAuthenticationProcessingFilter.java
+++ b/src/main/java/nextstep/security/authentication/AbstractAuthenticationProcessingFilter.java
@@ -1,0 +1,61 @@
+package nextstep.security.authentication;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import nextstep.security.access.RequestMatcher;
+import nextstep.security.context.SecurityContextHolder;
+import nextstep.security.oauth2.AuthenticationSuccessHandler;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+public abstract class AbstractAuthenticationProcessingFilter extends GenericFilterBean {
+
+    private final RequestMatcher requestMatcher;
+
+    private final AuthenticationSuccessHandler authenticationSuccessHandler;
+
+    public AbstractAuthenticationProcessingFilter(final RequestMatcher requestMatcher,
+                                                  final AuthenticationSuccessHandler authenticationSuccessHandler) {
+        this.requestMatcher = requestMatcher;
+        this.authenticationSuccessHandler = authenticationSuccessHandler;
+    }
+
+    @Override
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (!requiresAuthentication(request)) {
+            chain.doFilter(request, response);
+            return;
+        }
+        try {
+            var authenticationResult = attemptAuthentication(request, response);
+            if (authenticationResult == null) {
+                return;
+            }
+
+            authenticationSuccessHandler.onSuccess(request, response, authenticationResult);
+
+
+
+        } catch (AuthenticationException e) {
+            SecurityContextHolder.clearContext();
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED.getReasonPhrase());
+        }
+    }
+
+    abstract Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response);
+
+    private boolean requiresAuthentication(HttpServletRequest request) {
+        return requestMatcher.matches(request);
+    }
+
+}

--- a/src/main/java/nextstep/security/authentication/AbstractAuthenticationProcessingFilter.java
+++ b/src/main/java/nextstep/security/authentication/AbstractAuthenticationProcessingFilter.java
@@ -44,8 +44,6 @@ public abstract class AbstractAuthenticationProcessingFilter extends GenericFilt
             authenticationSuccessHandler.onSuccess(request, response, authenticationResult);
         } catch (AuthenticationException ex) {
             authenticationFailHandler.onFail(request, response, ex);
-        } catch (Exception ex) {
-            authenticationFailHandler.onFail(request, response, new AuthenticationException());
         }
     }
 

--- a/src/main/java/nextstep/security/authentication/AuthenticationFailHandler.java
+++ b/src/main/java/nextstep/security/authentication/AuthenticationFailHandler.java
@@ -1,0 +1,13 @@
+package nextstep.security.authentication;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import nextstep.security.authentication.Authentication;
+import nextstep.security.authentication.AuthenticationException;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface AuthenticationFailHandler {
+    void onFail(final HttpServletRequest request, final HttpServletResponse response, AuthenticationException exception) throws IOException;
+}

--- a/src/main/java/nextstep/security/authentication/AuthenticationSuccessHandler.java
+++ b/src/main/java/nextstep/security/authentication/AuthenticationSuccessHandler.java
@@ -1,11 +1,11 @@
-package nextstep.security.oauth2;
+package nextstep.security.authentication;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import nextstep.security.authentication.Authentication;
 
 import java.io.IOException;
 
+@FunctionalInterface
 public interface AuthenticationSuccessHandler {
 
     void onSuccess(final HttpServletRequest request, final HttpServletResponse response, Authentication authentication) throws IOException;

--- a/src/main/java/nextstep/security/authentication/DefaultAuthenticationFailHandler.java
+++ b/src/main/java/nextstep/security/authentication/DefaultAuthenticationFailHandler.java
@@ -1,0 +1,23 @@
+package nextstep.security.authentication;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+
+import java.io.IOException;
+
+public class DefaultAuthenticationFailHandler implements AuthenticationFailHandler {
+    private static final DefaultAuthenticationFailHandler INSTANCE = new DefaultAuthenticationFailHandler();
+
+    private DefaultAuthenticationFailHandler() {
+    }
+
+    public static DefaultAuthenticationFailHandler getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void onFail(final HttpServletRequest request, final HttpServletResponse response, final AuthenticationException exception) throws IOException {
+        response.sendError(HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED.getReasonPhrase());
+    }
+}

--- a/src/main/java/nextstep/security/authentication/UsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/nextstep/security/authentication/UsernamePasswordAuthenticationFilter.java
@@ -1,70 +1,31 @@
 package nextstep.security.authentication;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import nextstep.security.access.MvcRequestMatcher;
-import nextstep.security.context.HttpSessionSecurityContextRepository;
-import nextstep.security.context.SecurityContext;
-import nextstep.security.context.SecurityContextHolder;
+import nextstep.security.oauth2.AuthenticationSuccessHandler;
 import nextstep.security.userdetails.UserDetailsService;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.filter.GenericFilterBean;
 
-import java.io.IOException;
 import java.util.List;
 
-public class UsernamePasswordAuthenticationFilter extends GenericFilterBean {
+public class UsernamePasswordAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
     private static final MvcRequestMatcher DEFAULT_MVC_REQUEST_MATCHER = new MvcRequestMatcher(HttpMethod.POST, "/login");
     public static final String SPRING_SECURITY_FORM_USERNAME_KEY = "username";
     public static final String SPRING_SECURITY_FORM_PASSWORD_KEY = "password";
 
     private final AuthenticationManager authenticationManager;
-    private final HttpSessionSecurityContextRepository securityContextRepository = new HttpSessionSecurityContextRepository();
 
-    public UsernamePasswordAuthenticationFilter(UserDetailsService userDetailsService) {
+    public UsernamePasswordAuthenticationFilter(UserDetailsService userDetailsService,
+                                                AuthenticationSuccessHandler successHandler) {
+        super(DEFAULT_MVC_REQUEST_MATCHER, successHandler);
         this.authenticationManager = new ProviderManager(
                 List.of(new DaoAuthenticationProvider(userDetailsService))
         );
     }
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
-    }
-
-    public void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
-        if (!requiresAuthentication(request)) {
-            chain.doFilter(request, response);
-            return;
-        }
-
-        try {
-            Authentication authenticationResult = attemptAuthentication(request);
-            if (authenticationResult == null) {
-                return;
-            }
-
-            SecurityContext context = SecurityContextHolder.createEmptyContext();
-            context.setAuthentication(authenticationResult);
-            SecurityContextHolder.setContext(context);
-            this.securityContextRepository.saveContext(context, request, response);
-
-        } catch (AuthenticationException e) {
-            SecurityContextHolder.clearContext();
-            response.sendError(HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED.getReasonPhrase());
-        }
-    }
-
-    private boolean requiresAuthentication(HttpServletRequest request) {
-        return DEFAULT_MVC_REQUEST_MATCHER.matches(request);
-    }
-
-    private Authentication attemptAuthentication(HttpServletRequest request) {
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) {
         String username = obtainUsername(request);
         username = (username != null) ? username.trim() : "";
         String password = obtainPassword(request);

--- a/src/main/java/nextstep/security/authentication/UsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/nextstep/security/authentication/UsernamePasswordAuthenticationFilter.java
@@ -3,7 +3,6 @@ package nextstep.security.authentication;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import nextstep.security.access.MvcRequestMatcher;
-import nextstep.security.oauth2.AuthenticationSuccessHandler;
 import nextstep.security.userdetails.UserDetailsService;
 import org.springframework.http.HttpMethod;
 
@@ -18,7 +17,7 @@ public class UsernamePasswordAuthenticationFilter extends AbstractAuthentication
 
     public UsernamePasswordAuthenticationFilter(UserDetailsService userDetailsService,
                                                 AuthenticationSuccessHandler successHandler) {
-        super(DEFAULT_MVC_REQUEST_MATCHER, successHandler);
+        super(DEFAULT_MVC_REQUEST_MATCHER, successHandler, DefaultAuthenticationFailHandler.getInstance());
         this.authenticationManager = new ProviderManager(
                 List.of(new DaoAuthenticationProvider(userDetailsService))
         );

--- a/src/main/java/nextstep/security/authentication/UsernamePasswordAuthenticationSuccessHandler.java
+++ b/src/main/java/nextstep/security/authentication/UsernamePasswordAuthenticationSuccessHandler.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import nextstep.security.context.HttpSessionSecurityContextRepository;
 import nextstep.security.context.SecurityContext;
 import nextstep.security.context.SecurityContextHolder;
-import nextstep.security.oauth2.AuthenticationSuccessHandler;
 
 import java.io.IOException;
 

--- a/src/main/java/nextstep/security/authentication/UsernamePasswordAuthenticationSuccessHandler.java
+++ b/src/main/java/nextstep/security/authentication/UsernamePasswordAuthenticationSuccessHandler.java
@@ -1,0 +1,22 @@
+package nextstep.security.authentication;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import nextstep.security.context.HttpSessionSecurityContextRepository;
+import nextstep.security.context.SecurityContext;
+import nextstep.security.context.SecurityContextHolder;
+import nextstep.security.oauth2.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+
+public class UsernamePasswordAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+    private final HttpSessionSecurityContextRepository securityContextRepository = new HttpSessionSecurityContextRepository();
+
+    @Override
+    public void onSuccess(final HttpServletRequest request, final HttpServletResponse response, final Authentication authentication) throws IOException {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+        this.securityContextRepository.saveContext(context, request, response);
+    }
+}

--- a/src/main/java/nextstep/security/oauth2/AuthenticationSuccessHandler.java
+++ b/src/main/java/nextstep/security/oauth2/AuthenticationSuccessHandler.java
@@ -6,7 +6,7 @@ import nextstep.security.authentication.Authentication;
 
 import java.io.IOException;
 
-public interface OAuth2AuthenticationSuccessHandler {
+public interface AuthenticationSuccessHandler {
 
     void onSuccess(final HttpServletRequest request, final HttpServletResponse response, Authentication authentication) throws IOException;
 }

--- a/src/main/java/nextstep/security/oauth2/AuthorizationRequestRepository.java
+++ b/src/main/java/nextstep/security/oauth2/AuthorizationRequestRepository.java
@@ -1,0 +1,25 @@
+package nextstep.security.oauth2;
+
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class AuthorizationRequestRepository {
+    private static final String SESSION_NAME = "$AuthorizationRequest";
+
+    public void save(final HttpServletRequest httpServletRequest, final OAuth2AuthorizationRequest authorizationRequest) {
+        var session = httpServletRequest.getSession(true);
+        session.setAttribute(SESSION_NAME, authorizationRequest);
+    }
+
+    @Nullable
+    public OAuth2AuthorizationRequest get(final HttpServletRequest httpServletRequest) {
+        var session = httpServletRequest.getSession(false);
+        if (session == null) {
+            return null;
+        }
+        if (session.getAttribute(SESSION_NAME) instanceof OAuth2AuthorizationRequest authorizationRequest) {
+            return authorizationRequest;
+        }
+        return null;
+    }
+}

--- a/src/main/java/nextstep/security/oauth2/AuthorizationRequestRepository.java
+++ b/src/main/java/nextstep/security/oauth2/AuthorizationRequestRepository.java
@@ -4,7 +4,7 @@ import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 
 public class AuthorizationRequestRepository {
-    private static final String SESSION_NAME = "$AuthorizationRequest";
+    public static final String SESSION_NAME = "$AuthorizationRequest";
 
     public void save(final HttpServletRequest httpServletRequest, final OAuth2AuthorizationRequest authorizationRequest) {
         var session = httpServletRequest.getSession(true);

--- a/src/main/java/nextstep/security/oauth2/ClientRegistration.java
+++ b/src/main/java/nextstep/security/oauth2/ClientRegistration.java
@@ -1,0 +1,151 @@
+package nextstep.security.oauth2;
+
+
+import jakarta.annotation.Nullable;
+import nextstep.security.properties.OAuth2ClientProperties;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ClientRegistration {
+
+    private final String registrationId;
+
+    private final String clientId;
+
+    private final String clientSecret;
+
+    private final String redirectUri;
+
+    private final String responseType;
+
+    private final ProviderDetails providerDetails;
+
+    private final String scope;
+
+
+    public ClientRegistration(final String registrationId,
+                              final String clientId,
+                              final String clientSecret,
+                              final String redirectUri,
+                              final String responseType,
+                              final String scope,
+                              final String authorizeUri,
+                              final String tokenUri,
+                              final String userInfoUri
+    ) {
+        this.registrationId = registrationId;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.responseType = responseType;
+        this.scope = scope;
+        this.redirectUri = redirectUri;
+        this.providerDetails = new ProviderDetails(authorizeUri, tokenUri, userInfoUri);
+    }
+
+    public static Map<String, ClientRegistration> from(OAuth2ClientProperties oAuth2ClientProperties) {
+        var map = new HashMap<String, ClientRegistration>();
+
+        oAuth2ClientProperties.getRegistrations().forEach((key, value) -> {
+                    map.put(key,
+                            new ClientRegistration(
+                                    value.getRegistrationId(),
+                                    value.getClientId(),
+                                    value.getClientSecret(),
+                                    value.getRedirectUri(),
+                                    value.getResponseType(),
+                                    value.getScope(),
+                                    value.getAuthorizeUri(),
+                                    value.getTokenUri(),
+                                    value.getUserUri()
+                            ));
+                }
+        );
+
+        return map;
+    }
+
+    @Nullable
+    public String getGrantType() {
+        if (responseType == null) {
+            return null;
+        }
+        if (this.responseType.equals("code")) {
+            return "authorization_code";
+        }
+        return null;
+    }
+
+    public String getRegistrationId() {
+        return registrationId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+
+    public String getResponseType() {
+        return responseType;
+    }
+
+    public String getTokenUri() {
+        return this.providerDetails.tokenUri;
+    }
+
+    public String getAuthorizeUri() {
+        return this.providerDetails.authorizationUri;
+    }
+
+    public String getScope() {
+        return this.scope;
+    }
+
+    public String getUserUri() {
+        return this.providerDetails.userInfoEndpoint.uri;
+    }
+
+
+    public static class ProviderDetails implements Serializable {
+        private final String authorizationUri;
+
+        private final String tokenUri;
+
+        private final UserInfoEndpoint userInfoEndpoint;
+
+        public ProviderDetails(final String authorizationUri,
+                               final String tokenUri,
+                               final String userInfoUri) {
+            this.authorizationUri = authorizationUri;
+            this.tokenUri = tokenUri;
+            this.userInfoEndpoint = new UserInfoEndpoint(userInfoUri);
+        }
+
+        public String getAuthorizationUri() {
+            return this.authorizationUri;
+        }
+
+        public String getTokenUri() {
+            return this.tokenUri;
+        }
+
+
+        public UserInfoEndpoint getUserInfoEndpoint() {
+            return this.userInfoEndpoint;
+        }
+
+
+        public record UserInfoEndpoint(String uri) implements Serializable {
+
+        }
+
+    }
+}

--- a/src/main/java/nextstep/security/oauth2/OAuth2AccessTokenRequestProvider.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2AccessTokenRequestProvider.java
@@ -1,6 +1,5 @@
 package nextstep.security.oauth2;
 
-import nextstep.security.properties.Registration;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -13,13 +12,13 @@ import java.util.Map;
 public class OAuth2AccessTokenRequestProvider {
     private final RestTemplate restTemplate = new RestTemplate();
 
-    public String getAccessToken(final Registration registration, final String code) {
+    public String getAccessToken(final ClientRegistration registration, final String code) {
         Map<String, String> map = new HashMap<>();
         map.put(OAuth2Parameter.CLIENT_ID.getPath(), registration.getClientId());
         map.put(OAuth2Parameter.CLIENT_SECRET.getPath(), registration.getClientSecret());
         map.put(OAuth2Parameter.CODE.getPath(), code);
         map.put(OAuth2Parameter.GRANT_TYPE.getPath(), registration.getGrantType());
-        map.put(OAuth2Parameter.REDIRECT_URL.getPath(), registration.getRedirectUrl());
+        map.put(OAuth2Parameter.REDIRECT_URL.getPath(), registration.getRedirectUri());
         var response = doPost(registration.getTokenUri(), map);
         return (String) response.get("access_token");
     }

--- a/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequest.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequest.java
@@ -1,0 +1,24 @@
+package nextstep.security.oauth2;
+
+import nextstep.security.properties.Registration;
+import org.springframework.lang.NonNull;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class OAuth2AuthorizationRequest {
+
+    private final Registration registration;
+
+    public OAuth2AuthorizationRequest(Registration registration) {
+        this.registration = registration;
+    }
+
+    @NonNull
+    public String getRedirectPath() {
+        return UriComponentsBuilder.fromHttpUrl(registration.getAuthorizeUri())
+                .queryParam(OAuth2Parameter.CLIENT_ID.getPath(), registration.getClientId())
+                .queryParam(OAuth2Parameter.RESPONSE_TYPE.getPath(), OAuth2Parameter.RESPONSE_TYPE.getDefaultValue())
+                .queryParam(OAuth2Parameter.SCOPE.getPath(), registration.getScope())
+                .queryParam(OAuth2Parameter.REDIRECT_URL.getPath(), registration.getRedirectUrl())
+                .toUriString();
+    }
+}

--- a/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequest.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequest.java
@@ -1,14 +1,13 @@
 package nextstep.security.oauth2;
 
-import nextstep.security.properties.Registration;
 import org.springframework.lang.NonNull;
 import org.springframework.web.util.UriComponentsBuilder;
 
 public class OAuth2AuthorizationRequest {
 
-    private final Registration registration;
+    private final ClientRegistration registration;
 
-    public OAuth2AuthorizationRequest(Registration registration) {
+    public OAuth2AuthorizationRequest(ClientRegistration registration) {
         this.registration = registration;
     }
 
@@ -18,11 +17,11 @@ public class OAuth2AuthorizationRequest {
                 .queryParam(OAuth2Parameter.CLIENT_ID.getPath(), registration.getClientId())
                 .queryParam(OAuth2Parameter.RESPONSE_TYPE.getPath(), OAuth2Parameter.RESPONSE_TYPE.getDefaultValue())
                 .queryParam(OAuth2Parameter.SCOPE.getPath(), registration.getScope())
-                .queryParam(OAuth2Parameter.REDIRECT_URL.getPath(), registration.getRedirectUrl())
+                .queryParam(OAuth2Parameter.REDIRECT_URL.getPath(), registration.getRedirectUri())
                 .toUriString();
     }
 
-    public Registration getRegistration() {
+    public ClientRegistration getRegistration() {
         return registration;
     }
 }

--- a/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequest.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequest.java
@@ -21,4 +21,8 @@ public class OAuth2AuthorizationRequest {
                 .queryParam(OAuth2Parameter.REDIRECT_URL.getPath(), registration.getRedirectUrl())
                 .toUriString();
     }
+
+    public Registration getRegistration() {
+        return registration;
+    }
 }

--- a/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequestRedirectFilter.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequestRedirectFilter.java
@@ -17,10 +17,14 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
     private final RequestMatcher requestMatcher;
     private final OAuth2AuthorizationRequestResolver requestResolver;
 
+    private final AuthorizationRequestRepository authorizationRequestRepository;
+
     public OAuth2AuthorizationRequestRedirectFilter(
-            final OAuth2AuthorizationRequestResolver requestResolver) {
+            final OAuth2AuthorizationRequestResolver requestResolver,
+            final AuthorizationRequestRepository authorizationRequestRepository) {
         this.requestMatcher = new AntRequestMatcher(HttpMethod.GET, "/oauth2/authorization/**");
         this.requestResolver = requestResolver;
+        this.authorizationRequestRepository = authorizationRequestRepository;
     }
 
     @Override
@@ -30,13 +34,11 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
             return;
         }
         var oAuth2AuthorizationRequest = requestResolver.resolve(request);
-
         if (oAuth2AuthorizationRequest == null) {
             filterChain.doFilter(request, response);
             return;
         }
-
-
+        authorizationRequestRepository.save(request, oAuth2AuthorizationRequest);
         sendRedirectForAuthorization(request, response, oAuth2AuthorizationRequest);
     }
 

--- a/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequestRedirectFilter.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequestRedirectFilter.java
@@ -15,13 +15,13 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 
-public class OAuth2RedirectFilter extends GenericFilterBean {
+public class OAuth2AuthorizationRequestRedirectFilter extends GenericFilterBean {
 
     private final RequestMatcher requestMatcher;
     private final ClientRegistrationRepository clientRegistrationRepository;
 
 
-    public OAuth2RedirectFilter(final ClientRegistrationRepository clientRegistrationRepository) {
+    public OAuth2AuthorizationRequestRedirectFilter(final ClientRegistrationRepository clientRegistrationRepository) {
         this.requestMatcher = new AntRequestMatcher(HttpMethod.GET, "/oauth2/authorization/**");
         this.clientRegistrationRepository = clientRegistrationRepository;
     }

--- a/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequestRedirectFilter.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequestRedirectFilter.java
@@ -20,9 +20,10 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
     private final AuthorizationRequestRepository authorizationRequestRepository;
 
     public OAuth2AuthorizationRequestRedirectFilter(
+            final RequestMatcher requestMatcher,
             final OAuth2AuthorizationRequestResolver requestResolver,
             final AuthorizationRequestRepository authorizationRequestRepository) {
-        this.requestMatcher = new AntRequestMatcher(HttpMethod.GET, "/oauth2/authorization/**");
+        this.requestMatcher = requestMatcher;
         this.requestResolver = requestResolver;
         this.authorizationRequestRepository = authorizationRequestRepository;
     }

--- a/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequestResolver.java
@@ -2,6 +2,7 @@ package nextstep.security.oauth2;
 
 import jakarta.servlet.http.HttpServletRequest;
 import nextstep.security.properties.ClientRegistrationRepository;
+import nextstep.security.utils.UrlUtils;
 import org.springframework.lang.Nullable;
 
 public class OAuth2AuthorizationRequestResolver {
@@ -14,13 +15,11 @@ public class OAuth2AuthorizationRequestResolver {
 
     @Nullable
     public OAuth2AuthorizationRequest resolve(final HttpServletRequest request) {
-        var url = request.getRequestURI();
-        var vendor = url.substring(url.lastIndexOf("/") + 1);
-        var registration = clientRegistrationRepository.findRegistrationById(vendor);
+        var registrationId = UrlUtils.getLastPath(request);
+        var registration = clientRegistrationRepository.findRegistrationById(registrationId);
         if(registration == null) {
             return null;
         }
-
         return new OAuth2AuthorizationRequest(registration);
     }
 

--- a/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,27 @@
+package nextstep.security.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import nextstep.security.properties.ClientRegistrationRepository;
+import org.springframework.lang.Nullable;
+
+public class OAuth2AuthorizationRequestResolver {
+
+    private final ClientRegistrationRepository clientRegistrationRepository;
+
+    public OAuth2AuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+        this.clientRegistrationRepository = clientRegistrationRepository;
+    }
+
+    @Nullable
+    public OAuth2AuthorizationRequest resolve(final HttpServletRequest request) {
+        var url = request.getRequestURI();
+        var vendor = url.substring(url.lastIndexOf("/") + 1);
+        var registration = clientRegistrationRepository.findRegistrationById(vendor);
+        if(registration == null) {
+            return null;
+        }
+
+        return new OAuth2AuthorizationRequest(registration);
+    }
+
+}

--- a/src/main/java/nextstep/security/oauth2/OAuth2LoginAuthenticationFilter.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2LoginAuthenticationFilter.java
@@ -33,7 +33,6 @@ public class OAuth2LoginAuthenticationFilter extends GenericFilterBean {
     public OAuth2LoginAuthenticationFilter(final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler,
                                            final List<OAuth2UserDetailsService> userDetailsServices,
                                            final AuthorizationRequestRepository authorizationRequestRepository
-
     ) {
         this.oauth2UserDetailsServiceResolver = new OAuth2UserDetailsServiceResolver(userDetailsServices);
         this.oAuth2AuthenticationSuccessHandler = oAuth2AuthenticationSuccessHandler;

--- a/src/main/java/nextstep/security/oauth2/OAuth2LoginAuthenticationFilter.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2LoginAuthenticationFilter.java
@@ -1,58 +1,37 @@
 package nextstep.security.oauth2;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import nextstep.security.access.AntRequestMatcher;
-import nextstep.security.access.RequestMatcher;
-import nextstep.security.authentication.AuthenticationException;
-import nextstep.security.authentication.AuthenticationManager;
+import nextstep.security.authentication.*;
 import nextstep.security.oauth2.login.OAuth2LoginAuthenticationToken;
 import org.springframework.http.HttpMethod;
-import org.springframework.web.filter.GenericFilterBean;
-
-import java.io.IOException;
-import java.nio.file.AccessDeniedException;
 
 import static nextstep.security.properties.Registration.REDIRECT_URL_PREFIX;
 
-public class OAuth2LoginAuthenticationFilter extends GenericFilterBean {
+public class OAuth2LoginAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
     private static final String REDIRECT_MATCH_URL = REDIRECT_URL_PREFIX + "/**";
-    private final AuthenticationSuccessHandler authenticationSuccessHandler;
-    private final RequestMatcher requestMatcher = new AntRequestMatcher(HttpMethod.GET, REDIRECT_MATCH_URL);
     private final AuthorizationRequestRepository authorizationRequestRepository;
-
     private final AuthenticationManager authenticationManager;
 
 
     public OAuth2LoginAuthenticationFilter(final AuthenticationSuccessHandler authenticationSuccessHandler,
                                            final AuthorizationRequestRepository authorizationRequestRepository,
-                                           final AuthenticationManager authenticationManager
-    ) {
-        this.authenticationSuccessHandler = authenticationSuccessHandler;
+                                           final AuthenticationManager authenticationManager) {
+        super(new AntRequestMatcher(HttpMethod.GET, REDIRECT_MATCH_URL), authenticationSuccessHandler, DefaultAuthenticationFailHandler.getInstance());
         this.authorizationRequestRepository = authorizationRequestRepository;
         this.authenticationManager = authenticationManager;
     }
 
     @Override
-    public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse, final FilterChain filterChain) throws IOException, ServletException {
-        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-        HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
-        if (!requestMatcher.matches(httpServletRequest)) {
-            filterChain.doFilter(servletRequest, servletResponse);
-            return;
-        }
-        // request에서 parameter를 가져오기
-        var code = httpServletRequest.getParameter("code");
+    protected Authentication attemptAuthentication(final HttpServletRequest request, final HttpServletResponse response) {
+        var code = request.getParameter("code");
         if (code == null) {
             throw new AuthenticationException("인증 코드 정보가 존재하지 않습니다.");
         }
 
         // session에서 authorizationRequest를 가져오기
-        var authorizationRequest = authorizationRequestRepository.get(httpServletRequest);
+        var authorizationRequest = authorizationRequestRepository.get(request);
         if (authorizationRequest == null) {
             throw new AuthenticationException("인증 정보가 존재하지 않습니다.");
         }
@@ -65,11 +44,9 @@ public class OAuth2LoginAuthenticationFilter extends GenericFilterBean {
         );
 
         if (authenticated == null || !authenticated.isAuthenticated()) {
-            throw new AccessDeniedException("oauth2 인증에 실패했습니다.");
+            throw new AuthenticationException("oauth2 인증에 실패했습니다.");
         }
 
-        if (authenticated instanceof OAuth2LoginAuthenticationToken authenticationToken) {
-            authenticationSuccessHandler.onSuccess(httpServletRequest, httpServletResponse, authenticationToken);
-        }
+        return authenticated;
     }
 }

--- a/src/main/java/nextstep/security/oauth2/OAuth2LoginAuthenticationFilter.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2LoginAuthenticationFilter.java
@@ -8,11 +8,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import nextstep.security.access.AntRequestMatcher;
 import nextstep.security.access.RequestMatcher;
+import nextstep.security.authentication.AuthenticationException;
 import nextstep.security.authentication.OAuth2UserDetailsAuthenticationToken;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetailsService;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetailsServiceResolver;
 import nextstep.security.properties.ClientRegistrationRepository;
-import nextstep.security.utils.UrlUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.filter.GenericFilterBean;
 
@@ -21,21 +21,23 @@ import java.util.List;
 
 import static nextstep.security.properties.Registration.REDIRECT_URL_PREFIX;
 
-public class OAuth2AuthenticationFilter extends GenericFilterBean {
+public class OAuth2LoginAuthenticationFilter extends GenericFilterBean {
     private static final String REDIRECT_MATCH_URL = REDIRECT_URL_PREFIX + "/**";
-    private final ClientRegistrationRepository clientRegistrationRepository;
     private final OAuth2AccessTokenRequestProvider oAuth2AccessTokenRequestProvider = new OAuth2AccessTokenRequestProvider();
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final OAuth2UserDetailsServiceResolver oauth2UserDetailsServiceResolver;
     private final RequestMatcher requestMatcher = new AntRequestMatcher(HttpMethod.GET, REDIRECT_MATCH_URL);
 
-    public OAuth2AuthenticationFilter(final ClientRegistrationRepository clientRegistrationRepository,
-                                      final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler,
-                                      final List<OAuth2UserDetailsService> userDetailsServices
+    private final AuthorizationRequestRepository authorizationRequestRepository;
+
+    public OAuth2LoginAuthenticationFilter(final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler,
+                                           final List<OAuth2UserDetailsService> userDetailsServices,
+                                           final AuthorizationRequestRepository authorizationRequestRepository
+
     ) {
-        this.clientRegistrationRepository = clientRegistrationRepository;
         this.oauth2UserDetailsServiceResolver = new OAuth2UserDetailsServiceResolver(userDetailsServices);
         this.oAuth2AuthenticationSuccessHandler = oAuth2AuthenticationSuccessHandler;
+        this.authorizationRequestRepository = authorizationRequestRepository;
     }
 
     @Override
@@ -46,21 +48,19 @@ public class OAuth2AuthenticationFilter extends GenericFilterBean {
             filterChain.doFilter(servletRequest, servletResponse);
             return;
         }
-
-        var vendor = UrlUtils.getLastPath(httpServletRequest);
-        var registration = clientRegistrationRepository.findRegistrationById(vendor);
-        if (registration == null) {
-            filterChain.doFilter(servletRequest, servletResponse);
-            return;
+        var authorizationRequest = authorizationRequestRepository.get(httpServletRequest);
+        if(authorizationRequest == null) {
+            throw new AuthenticationException("인증 정보가 존재하지 않습니다.");
         }
+        var registration = authorizationRequest.getRegistration();
+
         var code = httpServletRequest.getParameter("code");
         if (code == null) {
             filterChain.doFilter(servletRequest, servletResponse);
             return;
         }
         var accessToken = oAuth2AccessTokenRequestProvider.getAccessToken(registration, code);
-
-        var oauth2DetailsService = oauth2UserDetailsServiceResolver.getService(registration.getVendor());
+        var oauth2DetailsService = oauth2UserDetailsServiceResolver.getService(registration.getRegistrationId());
 
         try {
             var userDetails = oauth2DetailsService.loadUserByAccessToken(accessToken);

--- a/src/main/java/nextstep/security/oauth2/OAuth2LoginAuthenticationFilter.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2LoginAuthenticationFilter.java
@@ -7,10 +7,8 @@ import nextstep.security.authentication.*;
 import nextstep.security.oauth2.login.OAuth2LoginAuthenticationToken;
 import org.springframework.http.HttpMethod;
 
-import static nextstep.security.properties.Registration.REDIRECT_URL_PREFIX;
-
 public class OAuth2LoginAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
-    private static final String REDIRECT_MATCH_URL = REDIRECT_URL_PREFIX + "/**";
+    private static final String REDIRECT_MATCH_URL = "/login/oauth2/code/*";
     private final AuthorizationRequestRepository authorizationRequestRepository;
     private final AuthenticationManager authenticationManager;
 

--- a/src/main/java/nextstep/security/oauth2/OAuth2LoginAuthenticationFilter.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2LoginAuthenticationFilter.java
@@ -9,34 +9,32 @@ import jakarta.servlet.http.HttpServletResponse;
 import nextstep.security.access.AntRequestMatcher;
 import nextstep.security.access.RequestMatcher;
 import nextstep.security.authentication.AuthenticationException;
-import nextstep.security.authentication.OAuth2UserDetailsAuthenticationToken;
-import nextstep.security.oauth2.userdetails.OAuth2UserDetailsService;
-import nextstep.security.oauth2.userdetails.OAuth2UserDetailsServiceResolver;
-import nextstep.security.properties.ClientRegistrationRepository;
+import nextstep.security.authentication.AuthenticationManager;
+import nextstep.security.oauth2.login.OAuth2LoginAuthenticationToken;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
-import java.util.List;
+import java.nio.file.AccessDeniedException;
 
 import static nextstep.security.properties.Registration.REDIRECT_URL_PREFIX;
 
 public class OAuth2LoginAuthenticationFilter extends GenericFilterBean {
     private static final String REDIRECT_MATCH_URL = REDIRECT_URL_PREFIX + "/**";
-    private final OAuth2AccessTokenRequestProvider oAuth2AccessTokenRequestProvider = new OAuth2AccessTokenRequestProvider();
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
-    private final OAuth2UserDetailsServiceResolver oauth2UserDetailsServiceResolver;
     private final RequestMatcher requestMatcher = new AntRequestMatcher(HttpMethod.GET, REDIRECT_MATCH_URL);
-
     private final AuthorizationRequestRepository authorizationRequestRepository;
 
+    private final AuthenticationManager authenticationManager;
+
+
     public OAuth2LoginAuthenticationFilter(final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler,
-                                           final List<OAuth2UserDetailsService> userDetailsServices,
-                                           final AuthorizationRequestRepository authorizationRequestRepository
+                                           final AuthorizationRequestRepository authorizationRequestRepository,
+                                           final AuthenticationManager authenticationManager
     ) {
-        this.oauth2UserDetailsServiceResolver = new OAuth2UserDetailsServiceResolver(userDetailsServices);
         this.oAuth2AuthenticationSuccessHandler = oAuth2AuthenticationSuccessHandler;
         this.authorizationRequestRepository = authorizationRequestRepository;
+        this.authenticationManager = authenticationManager;
     }
 
     @Override
@@ -47,27 +45,31 @@ public class OAuth2LoginAuthenticationFilter extends GenericFilterBean {
             filterChain.doFilter(servletRequest, servletResponse);
             return;
         }
-        var authorizationRequest = authorizationRequestRepository.get(httpServletRequest);
-        if(authorizationRequest == null) {
-            throw new AuthenticationException("인증 정보가 존재하지 않습니다.");
-        }
-        var registration = authorizationRequest.getRegistration();
-
+        // request에서 parameter를 가져오기
         var code = httpServletRequest.getParameter("code");
         if (code == null) {
-            filterChain.doFilter(servletRequest, servletResponse);
-            return;
+            throw new AuthenticationException("인증 코드 정보가 존재하지 않습니다.");
         }
-        var accessToken = oAuth2AccessTokenRequestProvider.getAccessToken(registration, code);
-        var oauth2DetailsService = oauth2UserDetailsServiceResolver.getService(registration.getRegistrationId());
 
-        try {
-            var userDetails = oauth2DetailsService.loadUserByAccessToken(accessToken);
-            var authenticatedToken = OAuth2UserDetailsAuthenticationToken
-                    .authenticated(userDetails.getUsername(), accessToken, userDetails.getAuthorities(), userDetails);
-            oAuth2AuthenticationSuccessHandler.onSuccess(httpServletRequest, httpServletResponse, authenticatedToken);
-        } catch (Exception ex) {
-            //TODO failHandler 구현
+        // session에서 authorizationRequest를 가져오기
+        var authorizationRequest = authorizationRequestRepository.get(httpServletRequest);
+        if (authorizationRequest == null) {
+            throw new AuthenticationException("인증 정보가 존재하지 않습니다.");
+        }
+
+        var authenticated = authenticationManager.authenticate(
+                OAuth2LoginAuthenticationToken.unauthenticated(
+                        code,
+                        authorizationRequest
+                )
+        );
+
+        if (authenticated == null || !authenticated.isAuthenticated()) {
+            throw new AccessDeniedException("oauth2 인증에 실패했습니다.");
+        }
+
+        if (authenticated instanceof OAuth2LoginAuthenticationToken authenticationToken) {
+            oAuth2AuthenticationSuccessHandler.onSuccess(httpServletRequest, httpServletResponse, authenticationToken);
         }
     }
 }

--- a/src/main/java/nextstep/security/oauth2/OAuth2LoginAuthenticationFilter.java
+++ b/src/main/java/nextstep/security/oauth2/OAuth2LoginAuthenticationFilter.java
@@ -21,18 +21,18 @@ import static nextstep.security.properties.Registration.REDIRECT_URL_PREFIX;
 
 public class OAuth2LoginAuthenticationFilter extends GenericFilterBean {
     private static final String REDIRECT_MATCH_URL = REDIRECT_URL_PREFIX + "/**";
-    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final AuthenticationSuccessHandler authenticationSuccessHandler;
     private final RequestMatcher requestMatcher = new AntRequestMatcher(HttpMethod.GET, REDIRECT_MATCH_URL);
     private final AuthorizationRequestRepository authorizationRequestRepository;
 
     private final AuthenticationManager authenticationManager;
 
 
-    public OAuth2LoginAuthenticationFilter(final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler,
+    public OAuth2LoginAuthenticationFilter(final AuthenticationSuccessHandler authenticationSuccessHandler,
                                            final AuthorizationRequestRepository authorizationRequestRepository,
                                            final AuthenticationManager authenticationManager
     ) {
-        this.oAuth2AuthenticationSuccessHandler = oAuth2AuthenticationSuccessHandler;
+        this.authenticationSuccessHandler = authenticationSuccessHandler;
         this.authorizationRequestRepository = authorizationRequestRepository;
         this.authenticationManager = authenticationManager;
     }
@@ -69,7 +69,7 @@ public class OAuth2LoginAuthenticationFilter extends GenericFilterBean {
         }
 
         if (authenticated instanceof OAuth2LoginAuthenticationToken authenticationToken) {
-            oAuth2AuthenticationSuccessHandler.onSuccess(httpServletRequest, httpServletResponse, authenticationToken);
+            authenticationSuccessHandler.onSuccess(httpServletRequest, httpServletResponse, authenticationToken);
         }
     }
 }

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2AuthorizationCodeAuthenticationProvider.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2AuthorizationCodeAuthenticationProvider.java
@@ -3,23 +3,11 @@ package nextstep.security.oauth2.login;
 import nextstep.security.authentication.Authentication;
 import nextstep.security.authentication.AuthenticationManager;
 import nextstep.security.oauth2.OAuth2AccessTokenRequestProvider;
-import nextstep.security.oauth2.userdetails.OAuth2UserDetailsService;
-import nextstep.security.oauth2.userdetails.OAuth2UserDetailsServiceResolver;
-
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class OAuth2AuthorizationCodeAuthenticationProvider implements AuthenticationManager {
-    private final Map<String, OAuth2UserDetailsService> userDetailsServiceMap;
-    private final OAuth2UserDetailsServiceResolver oauth2UserDetailsServiceResolver;
+
     private final OAuth2AccessTokenRequestProvider oAuth2AccessTokenRequestProvider = new OAuth2AccessTokenRequestProvider();
 
-    public OAuth2AuthorizationCodeAuthenticationProvider(final List<OAuth2UserDetailsService> userDetailsServices) {
-        this.userDetailsServiceMap = userDetailsServices.stream()
-                .collect(Collectors.toMap(OAuth2UserDetailsService::getRegistrationId, it -> it));
-        this.oauth2UserDetailsServiceResolver = new OAuth2UserDetailsServiceResolver(userDetailsServices);
-    }
 
     @Override
     public Authentication authenticate(final Authentication authentication) {
@@ -33,16 +21,13 @@ public class OAuth2AuthorizationCodeAuthenticationProvider implements Authentica
         try {
             var accessToken = oAuth2AccessTokenRequestProvider.getAccessToken(
                     token.getRegistration(), token.getPrincipal());
-
             return OAuth2AuthorizationCodeAuthenticationToken.authenticated(
                     token.getPrincipal(),
-                    token.getAuthorities(),
                     token.getRegistration(),
                     accessToken);
         } catch (Exception ex) {
             return OAuth2AuthorizationCodeAuthenticationToken.unauthenticated(
                     token.getPrincipal(),
-                    token.getAuthorities(),
                     token.getRegistration());
         }
     }

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2AuthorizationCodeAuthenticationProvider.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2AuthorizationCodeAuthenticationProvider.java
@@ -1,10 +1,10 @@
 package nextstep.security.oauth2.login;
 
 import nextstep.security.authentication.Authentication;
-import nextstep.security.authentication.AuthenticationManager;
+import nextstep.security.authentication.AuthenticationProvider;
 import nextstep.security.oauth2.OAuth2AccessTokenRequestProvider;
 
-public class OAuth2AuthorizationCodeAuthenticationProvider implements AuthenticationManager {
+public class OAuth2AuthorizationCodeAuthenticationProvider implements AuthenticationProvider {
 
     private final OAuth2AccessTokenRequestProvider oAuth2AccessTokenRequestProvider = new OAuth2AccessTokenRequestProvider();
 
@@ -15,6 +15,11 @@ public class OAuth2AuthorizationCodeAuthenticationProvider implements Authentica
             return createOAuth2AuthorizationCodeAuthenticationToken(token);
         }
         return null;
+    }
+
+    @Override
+    public boolean supports(final Class<?> authentication) {
+        return authentication == OAuth2AuthorizationCodeAuthenticationToken.class;
     }
 
     private OAuth2AuthorizationCodeAuthenticationToken createOAuth2AuthorizationCodeAuthenticationToken(final OAuth2AuthorizationCodeAuthenticationToken token) {

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2AuthorizationCodeAuthenticationProvider.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2AuthorizationCodeAuthenticationProvider.java
@@ -1,0 +1,51 @@
+package nextstep.security.oauth2.login;
+
+import nextstep.security.authentication.Authentication;
+import nextstep.security.authentication.AuthenticationManager;
+import nextstep.security.oauth2.OAuth2AccessTokenRequestProvider;
+import nextstep.security.oauth2.userdetails.OAuth2UserDetailsService;
+import nextstep.security.oauth2.userdetails.OAuth2UserDetailsServiceResolver;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class OAuth2AuthorizationCodeAuthenticationProvider implements AuthenticationManager {
+    private final Map<String, OAuth2UserDetailsService> userDetailsServiceMap;
+    private final OAuth2UserDetailsServiceResolver oauth2UserDetailsServiceResolver;
+    private final OAuth2AccessTokenRequestProvider oAuth2AccessTokenRequestProvider = new OAuth2AccessTokenRequestProvider();
+
+    public OAuth2AuthorizationCodeAuthenticationProvider(final List<OAuth2UserDetailsService> userDetailsServices) {
+        this.userDetailsServiceMap = userDetailsServices.stream()
+                .collect(Collectors.toMap(OAuth2UserDetailsService::getRegistrationId, it -> it));
+        this.oauth2UserDetailsServiceResolver = new OAuth2UserDetailsServiceResolver(userDetailsServices);
+    }
+
+    @Override
+    public Authentication authenticate(final Authentication authentication) {
+        if (authentication instanceof OAuth2AuthorizationCodeAuthenticationToken token) {
+            return createOAuth2AuthorizationCodeAuthenticationToken(token);
+        }
+        return null;
+    }
+
+    private OAuth2AuthorizationCodeAuthenticationToken createOAuth2AuthorizationCodeAuthenticationToken(final OAuth2AuthorizationCodeAuthenticationToken token) {
+        try {
+            var accessToken = oAuth2AccessTokenRequestProvider.getAccessToken(
+                    token.getRegistration(), token.getPrincipal());
+
+            return OAuth2AuthorizationCodeAuthenticationToken.authenticated(
+                    token.getPrincipal(),
+                    token.getAuthorities(),
+                    token.getRegistration(),
+                    accessToken);
+        } catch (Exception ex) {
+            return OAuth2AuthorizationCodeAuthenticationToken.unauthenticated(
+                    token.getPrincipal(),
+                    token.getAuthorities(),
+                    token.getRegistration());
+        }
+    }
+
+
+}

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2AuthorizationCodeAuthenticationToken.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2AuthorizationCodeAuthenticationToken.java
@@ -1,7 +1,7 @@
 package nextstep.security.oauth2.login;
 
 import nextstep.security.authentication.Authentication;
-import nextstep.security.properties.Registration;
+import nextstep.security.oauth2.ClientRegistration;
 
 import java.util.Set;
 
@@ -11,14 +11,14 @@ public class OAuth2AuthorizationCodeAuthenticationToken implements Authenticatio
 
     private final boolean authenticated;
 
-    private final Registration registration;
+    private final ClientRegistration registration;
 
     private final String accessToken;
 
 
     private OAuth2AuthorizationCodeAuthenticationToken(final String code,
                                                        final boolean authenticated,
-                                                       final Registration registration,
+                                                       final ClientRegistration registration,
                                                        final String accessToken) {
         this.code = code;
         this.authenticated = authenticated;
@@ -27,14 +27,14 @@ public class OAuth2AuthorizationCodeAuthenticationToken implements Authenticatio
     }
 
     public static OAuth2AuthorizationCodeAuthenticationToken unauthenticated(final String code,
-                                                                             final Registration registration
+                                                                             final ClientRegistration registration
 
     ) {
         return new OAuth2AuthorizationCodeAuthenticationToken(code, false, registration, null);
     }
 
     public static OAuth2AuthorizationCodeAuthenticationToken authenticated(String code,
-                                                                           final Registration registration,
+                                                                           final ClientRegistration registration,
                                                                            final String accessToken) {
         return new OAuth2AuthorizationCodeAuthenticationToken(code, true, registration, accessToken);
     }
@@ -59,7 +59,7 @@ public class OAuth2AuthorizationCodeAuthenticationToken implements Authenticatio
         return this.authenticated;
     }
 
-    public Registration getRegistration() {
+    public ClientRegistration getRegistration() {
         return registration;
     }
 

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2AuthorizationCodeAuthenticationToken.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2AuthorizationCodeAuthenticationToken.java
@@ -11,8 +11,6 @@ public class OAuth2AuthorizationCodeAuthenticationToken implements Authenticatio
 
     private final boolean authenticated;
 
-    private final Set<String> authorities;
-
     private final Registration registration;
 
     private final String accessToken;
@@ -20,29 +18,25 @@ public class OAuth2AuthorizationCodeAuthenticationToken implements Authenticatio
 
     private OAuth2AuthorizationCodeAuthenticationToken(final String code,
                                                        final boolean authenticated,
-                                                       final Set<String> authorities,
                                                        final Registration registration,
                                                        final String accessToken) {
         this.code = code;
         this.authenticated = authenticated;
-        this.authorities = authorities;
         this.registration = registration;
         this.accessToken = accessToken;
     }
 
     public static OAuth2AuthorizationCodeAuthenticationToken unauthenticated(final String code,
-                                                                             final Set<String> authorities,
                                                                              final Registration registration
 
     ) {
-        return new OAuth2AuthorizationCodeAuthenticationToken(code, false, authorities, registration, null);
+        return new OAuth2AuthorizationCodeAuthenticationToken(code, false, registration, null);
     }
 
     public static OAuth2AuthorizationCodeAuthenticationToken authenticated(String code,
-                                                                           Set<String> authorities,
                                                                            final Registration registration,
                                                                            final String accessToken) {
-        return new OAuth2AuthorizationCodeAuthenticationToken(code, true, authorities, registration, accessToken);
+        return new OAuth2AuthorizationCodeAuthenticationToken(code, true, registration, accessToken);
     }
 
     @Override
@@ -67,5 +61,9 @@ public class OAuth2AuthorizationCodeAuthenticationToken implements Authenticatio
 
     public Registration getRegistration() {
         return registration;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
     }
 }

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2AuthorizationCodeAuthenticationToken.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2AuthorizationCodeAuthenticationToken.java
@@ -1,0 +1,71 @@
+package nextstep.security.oauth2.login;
+
+import nextstep.security.authentication.Authentication;
+import nextstep.security.properties.Registration;
+
+import java.util.Set;
+
+public class OAuth2AuthorizationCodeAuthenticationToken implements Authentication {
+
+    private final String code;
+
+    private final boolean authenticated;
+
+    private final Set<String> authorities;
+
+    private final Registration registration;
+
+    private final String accessToken;
+
+
+    private OAuth2AuthorizationCodeAuthenticationToken(final String code,
+                                                       final boolean authenticated,
+                                                       final Set<String> authorities,
+                                                       final Registration registration,
+                                                       final String accessToken) {
+        this.code = code;
+        this.authenticated = authenticated;
+        this.authorities = authorities;
+        this.registration = registration;
+        this.accessToken = accessToken;
+    }
+
+    public static OAuth2AuthorizationCodeAuthenticationToken unauthenticated(final String code,
+                                                                             final Set<String> authorities,
+                                                                             final Registration registration
+
+    ) {
+        return new OAuth2AuthorizationCodeAuthenticationToken(code, false, authorities, registration, null);
+    }
+
+    public static OAuth2AuthorizationCodeAuthenticationToken authenticated(String code,
+                                                                           Set<String> authorities,
+                                                                           final Registration registration,
+                                                                           final String accessToken) {
+        return new OAuth2AuthorizationCodeAuthenticationToken(code, true, authorities, registration, accessToken);
+    }
+
+    @Override
+    public Set<String> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getCredentials() {
+        return this.code;
+    }
+
+    @Override
+    public String getPrincipal() {
+        return this.code;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return this.authenticated;
+    }
+
+    public Registration getRegistration() {
+        return registration;
+    }
+}

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationProvider.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationProvider.java
@@ -24,7 +24,7 @@ public class OAuth2LoginAuthenticationProvider implements AuthenticationManager 
         if (authentication instanceof OAuth2LoginAuthenticationToken token) {
             var registration = token.getRegistration();
             var oAuth2AuthorizationCodeAuthenticationToken = authenticationManager.authenticate(OAuth2AuthorizationCodeAuthenticationToken.unauthenticated(token.getPrincipal(), //code가 들어있음
-                    token.getAuthorities(), registration));
+                    registration));
             return createOAuth2LoginAuthenticationTokenResponse(registration, oAuth2AuthorizationCodeAuthenticationToken);
         }
         return null;

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationProvider.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationProvider.java
@@ -2,8 +2,8 @@ package nextstep.security.oauth2.login;
 
 import jakarta.annotation.Nullable;
 import nextstep.security.authentication.Authentication;
+import nextstep.security.authentication.AuthenticationException;
 import nextstep.security.authentication.AuthenticationManager;
-import nextstep.security.authorization.AccessDeniedException;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetailsService;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetailsServiceResolver;
 import nextstep.security.properties.Registration;
@@ -32,7 +32,7 @@ public class OAuth2LoginAuthenticationProvider implements AuthenticationManager 
 
     private OAuth2LoginAuthenticationToken createOAuth2LoginAuthenticationTokenResponse(final Registration registration, final Authentication authentication) {
         if (!authentication.isAuthenticated()) {
-            throw new AccessDeniedException("code 정보로부터 accessToken 을 받아오는데 실패했습니다.");
+            throw new AuthenticationException("code 정보로부터 accessToken 을 받아오는데 실패했습니다.");
         }
         if (!(authentication instanceof final OAuth2AuthorizationCodeAuthenticationToken oAuth2AuthorizationCodeAuthenticationToken)) {
             return null;
@@ -43,7 +43,7 @@ public class OAuth2LoginAuthenticationProvider implements AuthenticationManager 
             var userDetails = oauth2DetailsService.loadUserByAccessToken(oAuth2AuthorizationCodeAuthenticationToken.getAccessToken());
             return OAuth2LoginAuthenticationToken.authenticated(userDetails);
         } catch (Exception ex) {
-            throw new AccessDeniedException("accessToken 으로 부터 userInfo를 받아오는데 실패했습니다.");
+            throw new AuthenticationException("accessToken 으로 부터 userInfo를 받아오는데 실패했습니다.");
         }
     }
 

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationProvider.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationProvider.java
@@ -4,9 +4,9 @@ import jakarta.annotation.Nullable;
 import nextstep.security.authentication.Authentication;
 import nextstep.security.authentication.AuthenticationException;
 import nextstep.security.authentication.AuthenticationProvider;
+import nextstep.security.oauth2.ClientRegistration;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetailsService;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetailsServiceResolver;
-import nextstep.security.properties.Registration;
 
 import java.util.List;
 
@@ -33,7 +33,7 @@ public class OAuth2LoginAuthenticationProvider implements AuthenticationProvider
         return authentication == OAuth2LoginAuthenticationToken.class;
     }
 
-    private OAuth2LoginAuthenticationToken createOAuth2LoginAuthenticationTokenResponse(final Registration registration, final Authentication authentication) {
+    private OAuth2LoginAuthenticationToken createOAuth2LoginAuthenticationTokenResponse(final ClientRegistration registration, final Authentication authentication) {
         if (!authentication.isAuthenticated()) {
             throw new AuthenticationException("code 정보로부터 accessToken 을 받아오는데 실패했습니다.");
         }

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationProvider.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationProvider.java
@@ -1,0 +1,46 @@
+package nextstep.security.oauth2.login;
+
+import jakarta.annotation.Nullable;
+import nextstep.security.authentication.Authentication;
+import nextstep.security.authentication.AuthenticationManager;
+import nextstep.security.authorization.AccessDeniedException;
+import nextstep.security.oauth2.userdetails.OAuth2UserDetailsService;
+import nextstep.security.oauth2.userdetails.OAuth2UserDetailsServiceResolver;
+
+import java.util.List;
+
+public class OAuth2LoginAuthenticationProvider implements AuthenticationManager {
+    private final AuthenticationManager authenticationManager = new OAuth2AuthorizationCodeAuthenticationProvider();
+    private final OAuth2UserDetailsServiceResolver oauth2UserDetailsServiceResolver;
+
+    public OAuth2LoginAuthenticationProvider(final List<OAuth2UserDetailsService> userDetailsServices) {
+        this.oauth2UserDetailsServiceResolver = new OAuth2UserDetailsServiceResolver(userDetailsServices);
+    }
+
+    @Nullable
+    @Override
+    public Authentication authenticate(final Authentication authentication) {
+        if (authentication instanceof OAuth2LoginAuthenticationToken token) {
+            var registration = token.getRegistration();
+            var oAuth2AuthorizationCodeAuthenticationToken = authenticationManager.authenticate(OAuth2AuthorizationCodeAuthenticationToken.unauthenticated(token.getPrincipal(), //code가 들어있음
+                    token.getAuthorities(), registration));
+
+            if (!oAuth2AuthorizationCodeAuthenticationToken.isAuthenticated()) {
+                throw new AccessDeniedException("code 정보로부터 accessToken 을 받아오는데 실패했습니다.");
+            }
+            if (oAuth2AuthorizationCodeAuthenticationToken instanceof OAuth2AuthorizationCodeAuthenticationToken codeToken) {
+                var oauth2DetailsService = oauth2UserDetailsServiceResolver.getService(registration.getRegistrationId());
+                try {
+                    var userDetails = oauth2DetailsService.loadUserByAccessToken(codeToken.getAccessToken());
+                    return OAuth2LoginAuthenticationToken.authenticated(userDetails);
+                } catch (Exception ex) {
+                    throw new AccessDeniedException("accessToken 으로 부터 userInfo를 받아오는데 실패했습니다.");
+                }
+            }
+            return null;
+        }
+        return null;
+    }
+
+
+}

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationProvider.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationProvider.java
@@ -3,7 +3,6 @@ package nextstep.security.oauth2.login;
 import jakarta.annotation.Nullable;
 import nextstep.security.authentication.Authentication;
 import nextstep.security.authentication.AuthenticationException;
-import nextstep.security.authentication.AuthenticationManager;
 import nextstep.security.authentication.AuthenticationProvider;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetailsService;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetailsServiceResolver;
@@ -11,7 +10,7 @@ import nextstep.security.properties.Registration;
 
 import java.util.List;
 
-public class OAuth2LoginAuthenticationProvider implements AuthenticationManager {
+public class OAuth2LoginAuthenticationProvider implements AuthenticationProvider {
     private final AuthenticationProvider authenticationProvider = new OAuth2AuthorizationCodeAuthenticationProvider();
     private final OAuth2UserDetailsServiceResolver oauth2UserDetailsServiceResolver;
 
@@ -22,13 +21,16 @@ public class OAuth2LoginAuthenticationProvider implements AuthenticationManager 
     @Nullable
     @Override
     public Authentication authenticate(final Authentication authentication) {
-        if (authentication instanceof OAuth2LoginAuthenticationToken token) {
-            var registration = token.getRegistration();
-            var oAuth2AuthorizationCodeAuthenticationToken = authenticationProvider.authenticate(OAuth2AuthorizationCodeAuthenticationToken.unauthenticated(token.getPrincipal(), //code가 들어있음
-                    registration));
-            return createOAuth2LoginAuthenticationTokenResponse(registration, oAuth2AuthorizationCodeAuthenticationToken);
-        }
-        return null;
+        OAuth2LoginAuthenticationToken token = (OAuth2LoginAuthenticationToken) authentication;
+        var registration = token.getRegistration();
+        var oAuth2AuthorizationCodeAuthenticationToken = authenticationProvider.authenticate(OAuth2AuthorizationCodeAuthenticationToken.unauthenticated(token.getPrincipal(), //code가 들어있음
+                registration));
+        return createOAuth2LoginAuthenticationTokenResponse(registration, oAuth2AuthorizationCodeAuthenticationToken);
+    }
+
+    @Override
+    public boolean supports(final Class<?> authentication) {
+        return authentication == OAuth2LoginAuthenticationToken.class;
     }
 
     private OAuth2LoginAuthenticationToken createOAuth2LoginAuthenticationTokenResponse(final Registration registration, final Authentication authentication) {
@@ -46,6 +48,5 @@ public class OAuth2LoginAuthenticationProvider implements AuthenticationManager 
             throw new AuthenticationException("accessToken 으로 부터 userInfo를 받아오는데 실패했습니다.");
         }
     }
-
 
 }

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationToken.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationToken.java
@@ -1,9 +1,9 @@
 package nextstep.security.oauth2.login;
 
 import nextstep.security.authentication.Authentication;
+import nextstep.security.oauth2.ClientRegistration;
 import nextstep.security.oauth2.OAuth2AuthorizationRequest;
 import nextstep.security.oauth2.userdetails.OAuth2UserDetails;
-import nextstep.security.properties.Registration;
 
 import java.util.Set;
 
@@ -72,7 +72,7 @@ public class OAuth2LoginAuthenticationToken implements Authentication {
         return this.authenticated;
     }
 
-    public Registration getRegistration() {
+    public ClientRegistration getRegistration() {
         return this.oAuth2AuthorizationRequest.getRegistration();
     }
 

--- a/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationToken.java
+++ b/src/main/java/nextstep/security/oauth2/login/OAuth2LoginAuthenticationToken.java
@@ -1,0 +1,82 @@
+package nextstep.security.oauth2.login;
+
+import nextstep.security.authentication.Authentication;
+import nextstep.security.oauth2.OAuth2AuthorizationRequest;
+import nextstep.security.oauth2.userdetails.OAuth2UserDetails;
+import nextstep.security.properties.Registration;
+
+import java.util.Set;
+
+public class OAuth2LoginAuthenticationToken implements Authentication {
+
+    private final String code;
+
+    private final boolean authenticated;
+
+    private final Set<String> authorities;
+
+    private final OAuth2AuthorizationRequest oAuth2AuthorizationRequest;
+
+    private final OAuth2UserDetails oAuth2UserDetails;
+
+
+    public OAuth2LoginAuthenticationToken(final String code,
+                                          final boolean authenticated,
+                                          final Set<String> authorities,
+                                          final OAuth2AuthorizationRequest oAuth2AuthorizationRequest,
+                                          final OAuth2UserDetails oAuth2UserDetails
+    ) {
+        this.code = code;
+        this.authenticated = authenticated;
+        this.authorities = authorities;
+        this.oAuth2AuthorizationRequest = oAuth2AuthorizationRequest;
+        this.oAuth2UserDetails = oAuth2UserDetails;
+    }
+
+    public static OAuth2LoginAuthenticationToken authenticated(final OAuth2UserDetails oAuth2UserDetails) {
+        return new OAuth2LoginAuthenticationToken(
+                oAuth2UserDetails.getUsername(),
+                true,
+                oAuth2UserDetails.getAuthorities(),
+                null,
+                oAuth2UserDetails);
+    }
+
+    public static OAuth2LoginAuthenticationToken unauthenticated(final String principal,
+                                                                 final OAuth2AuthorizationRequest request
+    ) {
+        return new OAuth2LoginAuthenticationToken(principal,
+                false,
+                null,
+                request,
+                null);
+    }
+
+    @Override
+    public Set<String> getAuthorities() {
+        return this.authorities;
+    }
+
+    @Override
+    public String getCredentials() {
+        return this.code;
+    }
+
+    @Override
+    public String getPrincipal() {
+        return this.code;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return this.authenticated;
+    }
+
+    public Registration getRegistration() {
+        return this.oAuth2AuthorizationRequest.getRegistration();
+    }
+
+    public OAuth2UserDetails getOAuth2UserDetails() {
+        return oAuth2UserDetails;
+    }
+}

--- a/src/main/java/nextstep/security/oauth2/userdetails/AbstractOAuth2UserDetailsService.java
+++ b/src/main/java/nextstep/security/oauth2/userdetails/AbstractOAuth2UserDetailsService.java
@@ -1,5 +1,6 @@
 package nextstep.security.oauth2.userdetails;
 
+import nextstep.security.properties.ClientRegistrationRepository;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -7,9 +8,16 @@ import org.springframework.http.HttpMethod;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
+import java.util.Objects;
 
 public abstract class AbstractOAuth2UserDetailsService implements OAuth2UserDetailsService {
     private final RestTemplate restTemplate = new RestTemplate();
+
+    private final ClientRegistrationRepository clientRegistrationRepository;
+
+    public AbstractOAuth2UserDetailsService(final ClientRegistrationRepository clientRegistrationRepository) {
+        this.clientRegistrationRepository = clientRegistrationRepository;
+    }
 
     @Override
     public OAuth2UserDetails loadUserByAccessToken(String accessToken) {
@@ -27,6 +35,8 @@ public abstract class AbstractOAuth2UserDetailsService implements OAuth2UserDeta
 
     protected abstract OAuth2UserDetails createOauth2UserDetails(Map<String, Object> userResponse);
 
-    protected abstract String getUserUrl();
+    public String getUserUrl() {
+        return Objects.requireNonNull(clientRegistrationRepository.findRegistrationById(getRegistrationId())).getUserUri();
+    }
 
 }

--- a/src/main/java/nextstep/security/oauth2/userdetails/OAuth2UserDetailsService.java
+++ b/src/main/java/nextstep/security/oauth2/userdetails/OAuth2UserDetailsService.java
@@ -4,6 +4,6 @@ public interface OAuth2UserDetailsService {
 
     OAuth2UserDetails loadUserByAccessToken(String accessToken);
 
-    String getVendor();
+    String getRegistrationId();
 
 }

--- a/src/main/java/nextstep/security/oauth2/userdetails/OAuth2UserDetailsServiceResolver.java
+++ b/src/main/java/nextstep/security/oauth2/userdetails/OAuth2UserDetailsServiceResolver.java
@@ -11,7 +11,7 @@ public class OAuth2UserDetailsServiceResolver {
 
     public OAuth2UserDetailsServiceResolver(final List<OAuth2UserDetailsService> userDetailsServices) {
         this.userDetailsServiceMap = userDetailsServices.stream()
-                .collect(Collectors.toMap(OAuth2UserDetailsService::getVendor, it -> it));
+                .collect(Collectors.toMap(OAuth2UserDetailsService::getRegistrationId, it -> it));
 
     }
 

--- a/src/main/java/nextstep/security/properties/ClientRegistrationRepository.java
+++ b/src/main/java/nextstep/security/properties/ClientRegistrationRepository.java
@@ -1,8 +1,9 @@
 package nextstep.security.properties;
 
 import jakarta.annotation.Nullable;
+import nextstep.security.oauth2.ClientRegistration;
 
 public interface ClientRegistrationRepository {
     @Nullable
-    Registration findRegistrationById(final String id);
+    ClientRegistration findRegistrationById(final String id);
 }

--- a/src/main/java/nextstep/security/properties/OAuth2ClientProperties.java
+++ b/src/main/java/nextstep/security/properties/OAuth2ClientProperties.java
@@ -10,13 +10,15 @@ import java.util.Map;
 @ConfigurationProperties(prefix = "security.oauth2")
 public class OAuth2ClientProperties {
     private Map<String, Registration> registration = new HashMap<>();
-    private String domain;
+
+    public Map<String, Registration> getRegistrations() {
+        return registration;
+    }
 
     @PostConstruct
     public void init() {
         registration.forEach((key, value) -> {
                     value.setRegistrationId(key);
-                    value.setDomain(domain);
                 }
         );
     }
@@ -28,14 +30,6 @@ public class OAuth2ClientProperties {
 
     public void setRegistration(final Map<String, Registration> registration) {
         this.registration = registration;
-    }
-
-    public String getDomain() {
-        return domain;
-    }
-
-    public void setDomain(final String domain) {
-        this.domain = domain;
     }
 
 }

--- a/src/main/java/nextstep/security/properties/OAuth2ClientProperties.java
+++ b/src/main/java/nextstep/security/properties/OAuth2ClientProperties.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @ConfigurationProperties(prefix = "security.oauth2")
-public class OAuth2Properties {
+public class OAuth2ClientProperties {
     private Map<String, Registration> registration = new HashMap<>();
     private String domain;
 

--- a/src/main/java/nextstep/security/properties/OAuth2ClientProperties.java
+++ b/src/main/java/nextstep/security/properties/OAuth2ClientProperties.java
@@ -15,7 +15,7 @@ public class OAuth2ClientProperties {
     @PostConstruct
     public void init() {
         registration.forEach((key, value) -> {
-                    value.setVendor(key);
+                    value.setRegistrationId(key);
                     value.setDomain(domain);
                 }
         );

--- a/src/main/java/nextstep/security/properties/Registration.java
+++ b/src/main/java/nextstep/security/properties/Registration.java
@@ -12,7 +12,7 @@ public class Registration {
     private String authorizeUri;
     private String tokenUri;
 
-    private String vendor;
+    private String registrationId;
 
     private String domain;
 
@@ -65,12 +65,12 @@ public class Registration {
         this.authorizeUri = authorizeUri;
     }
 
-    public String getVendor() {
-        return vendor;
+    public String getRegistrationId() {
+        return registrationId;
     }
 
-    public void setVendor(final String vendor) {
-        this.vendor = vendor;
+    public void setRegistrationId(final String registrationId) {
+        this.registrationId = registrationId;
     }
 
     @Nullable
@@ -89,6 +89,6 @@ public class Registration {
     }
 
     public String getRedirectUrl() {
-        return domain + REDIRECT_URL_PREFIX + "/" + vendor;
+        return domain + REDIRECT_URL_PREFIX + "/" + registrationId;
     }
 }

--- a/src/main/java/nextstep/security/properties/Registration.java
+++ b/src/main/java/nextstep/security/properties/Registration.java
@@ -1,10 +1,6 @@
 package nextstep.security.properties;
 
-import jakarta.annotation.Nullable;
-
 public class Registration {
-    public static final String REDIRECT_URL_PREFIX = "/login/oauth2/code";
-
     private String clientId;
     private String clientSecret;
     private String responseType;
@@ -12,9 +8,9 @@ public class Registration {
     private String authorizeUri;
     private String tokenUri;
 
+    private String userUri;
+    private String redirectUri;
     private String registrationId;
-
-    private String domain;
 
 
     public String getClientId() {
@@ -73,22 +69,20 @@ public class Registration {
         this.registrationId = registrationId;
     }
 
-    @Nullable
-    public String getGrantType() {
-        if (responseType == null) {
-            return null;
-        }
-        if (this.responseType.equals("code")) {
-            return "authorization_code";
-        }
-        return null;
+    public String getRedirectUri() {
+        return this.redirectUri;
     }
 
-    public void setDomain(final String domain) {
-        this.domain = domain;
+    public void setRedirectUri(final String redirectUri) {
+        this.redirectUri = redirectUri;
     }
 
-    public String getRedirectUrl() {
-        return domain + REDIRECT_URL_PREFIX + "/" + registrationId;
+    public String getUserUri() {
+        return userUri;
     }
+
+    public void setUserUri(final String userUri) {
+        this.userUri = userUri;
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,8 @@ security:
         scope: read:user
         authorize-uri: https://github.com/login/oauth/authorize
         token-uri: https://github.com/login/oauth/access_token
+        user-uri: https://api.github.com/user
+        redirect-uri: http://localhost:8080/login/oauth2/code
       google:
         client-secret: client-secret
         client-id: client-id
@@ -20,11 +22,5 @@ security:
         scope: https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile
         authorize-uri: https://accounts.google.com/o/oauth2/v2/auth
         token-uri: https://oauth2.googleapis.com/token
-
-
-app:
-  oauth2:
-    github:
-      user-url: https://api.github.com/user
-    google:
-      user-url: https://www.googleapis.com/oauth2/v2/userinfo
+        user-uri: https://www.googleapis.com/oauth2/v2/userinfo
+        redirect-uri: http://localhost:8080/login/oauth2/code

--- a/src/test/java/nextstep/app/OAuth2AuthorizationRequestRedirectFilterTest.java
+++ b/src/test/java/nextstep/app/OAuth2AuthorizationRequestRedirectFilterTest.java
@@ -13,7 +13,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-class OAuth2RedirectFilterTest {
+class OAuth2AuthorizationRequestRedirectFilterTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/nextstep/app/OAuth2LoginAuthenticationFilterTest.java
+++ b/src/test/java/nextstep/app/OAuth2LoginAuthenticationFilterTest.java
@@ -2,6 +2,8 @@ package nextstep.app;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nextstep.fixture.AuthorizationRequestFixture;
+import nextstep.security.oauth2.AuthorizationRequestRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureWireMock(port = 8089)
-class OAuth2AuthenticationFilterTest {
+class OAuth2LoginAuthenticationFilterTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -45,6 +47,9 @@ class OAuth2AuthenticationFilterTest {
     void githubRedirectAndRequestGithubAccessToken() throws Exception {
         String requestUri = "/login/oauth2/code/github?code=mock_code";
         MockHttpSession session = new MockHttpSession();
+        session.setAttribute(AuthorizationRequestRepository.SESSION_NAME,
+                AuthorizationRequestFixture.GITHUB.getOAuth2AuthorizationRequest()
+                );
 
         mockMvc.perform(MockMvcRequestBuilders.get(requestUri)
                         .session(session))
@@ -68,6 +73,9 @@ class OAuth2AuthenticationFilterTest {
     void googleAndRequestGithubAccessToken() throws Exception {
         String requestUri = "/login/oauth2/code/google?code=mock_code";
         MockHttpSession session = new MockHttpSession();
+        session.setAttribute(AuthorizationRequestRepository.SESSION_NAME,
+                AuthorizationRequestFixture.GOOGLE.getOAuth2AuthorizationRequest()
+        );
 
         mockMvc.perform(MockMvcRequestBuilders.get(requestUri)
                         .session(session))

--- a/src/test/java/nextstep/fixture/AuthorizationRequestFixture.java
+++ b/src/test/java/nextstep/fixture/AuthorizationRequestFixture.java
@@ -1,33 +1,41 @@
 package nextstep.fixture;
 
+import nextstep.security.oauth2.ClientRegistration;
 import nextstep.security.oauth2.OAuth2AuthorizationRequest;
-import nextstep.security.properties.Registration;
 
 public enum AuthorizationRequestFixture {
 
     GITHUB {
         @Override
         public OAuth2AuthorizationRequest getOAuth2AuthorizationRequest() {
-            var registration = new Registration();
-            registration.setDomain("http://localhost:8080");
-            registration.setClientSecret("client-secret-test");
-            registration.setClientId("client-id-test");
-            registration.setAuthorizeUri("https://github.com/login/oauth/authorize");
-            registration.setTokenUri("http://localhost:8089/login/oauth/access_token");
-            registration.setRegistrationId("github");
+            var registration = new ClientRegistration(
+                    "github",
+                    "client-id-test",
+                    "client-secret-test",
+                    "http://localhost:8080/login/oauth2/code",
+                    null,
+                    null,
+                    "https://github.com/login/oauth/authorize",
+                    "http://localhost:8089/login/oauth/access_token"
+                    , null
+            );
             return new OAuth2AuthorizationRequest(registration);
         }
     },
     GOOGLE {
         @Override
         public OAuth2AuthorizationRequest getOAuth2AuthorizationRequest() {
-            var registration = new Registration();
-            registration.setDomain("http://localhost:8080");
-            registration.setClientSecret("client-secret-test");
-            registration.setClientId("client-id-test");
-            registration.setAuthorizeUri("https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile");
-            registration.setTokenUri("http://localhost:8089/token");
-            registration.setRegistrationId("google");
+            var registration = new ClientRegistration(
+                    "google",
+                    "client-id-test",
+                    "client-secret-test",
+                    "http://localhost:8080/login/oauth2/code",
+                    null,
+                    null,
+                    "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile",
+                    "http://localhost:8089/token"
+                    , null
+            );
             return new OAuth2AuthorizationRequest(registration);
         }
     };

--- a/src/test/java/nextstep/fixture/AuthorizationRequestFixture.java
+++ b/src/test/java/nextstep/fixture/AuthorizationRequestFixture.java
@@ -1,0 +1,36 @@
+package nextstep.fixture;
+
+import nextstep.security.oauth2.OAuth2AuthorizationRequest;
+import nextstep.security.properties.Registration;
+
+public enum AuthorizationRequestFixture {
+
+    GITHUB {
+        @Override
+        public OAuth2AuthorizationRequest getOAuth2AuthorizationRequest() {
+            var registration = new Registration();
+            registration.setDomain("http://localhost:8080");
+            registration.setClientSecret("client-secret-test");
+            registration.setClientId("client-id-test");
+            registration.setAuthorizeUri("https://github.com/login/oauth/authorize");
+            registration.setTokenUri("http://localhost:8089/login/oauth/access_token");
+            registration.setRegistrationId("github");
+            return new OAuth2AuthorizationRequest(registration);
+        }
+    },
+    GOOGLE {
+        @Override
+        public OAuth2AuthorizationRequest getOAuth2AuthorizationRequest() {
+            var registration = new Registration();
+            registration.setDomain("http://localhost:8080");
+            registration.setClientSecret("client-secret-test");
+            registration.setClientId("client-id-test");
+            registration.setAuthorizeUri("https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile");
+            registration.setTokenUri("http://localhost:8089/token");
+            registration.setRegistrationId("google");
+            return new OAuth2AuthorizationRequest(registration);
+        }
+    };
+
+    public abstract OAuth2AuthorizationRequest getOAuth2AuthorizationRequest();
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,7 +8,9 @@ security:
         response-type: code
         scope: read:user
         authorize-uri: https://github.com/login/oauth/authorize
-        token-uri: http://localhost:8089/login/oauth/access_token
+        token-uri: http://localhost:8089/login/oauth/access_t
+        user-uri: http://localhost:8089/user
+        redirect-uri: http://localhost:8080/login/oauth2/code/github
       google:
         client-secret: client-secret-test
         client-id: client-id-test
@@ -16,11 +18,5 @@ security:
         scope: https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile
         authorize-uri: https://accounts.google.com/o/oauth2/v2/auth
         token-uri: http://localhost:8089/token
-
-app:
-  oauth2:
-    github:
-      user-url: http://localhost:8089/user
-    google:
-      user-url: http://localhost:8089/oauth2/v2/userinfo
-
+        user-uri: http://localhost:8089/oauth2/v2/userinfo
+        redirect-uri: http://localhost:8080/login/oauth2/code/google


### PR DESCRIPTION
안녕하세요 리뷰어님~ 
필터 시퀀스 다이어그램보면서 열심히 구현했습니다. 
길을 잃는다는게 뭔지 알겠더라구요.

구현중에 너무 힘들고 이해가 안가서 질문드립니다. 😥
OAuth2 인증 필터 구조가 너무 복잡한 것 같습니다. 
굳이 AuthenticationManager를 사용했어야 하나? 그냥 새로운 객체 만들어서 구현하는게 더 쉽지 않은가 싶어서요.
AuthenticationManger 마다 Authentication 객체가 정해져있어서 파라미터를 계속 캐스팅해서 사용해야하는데 
오히려 소스 파악하기 너무 힘든 것 같아요. 
필터 시퀀스 다이어그램 없었으면 아예 파악하지 못했을 것 같습니다.

AuthenticationManager - Authentication 간 거의 쌍으로 움직인다는 느낌이 들어서 차라리 제네릭이라도 썼으면 좋았을텐데 싶기도 하구요.

이렇게 리팩토링한 소스가 전 미션에서 구현한 소스보다 훨배 파악이 어려운거같아서 ㅠㅠ이게맞나..이게맞나..?하면서 구현했습니다.

OAuth2AccessToeknResponseClient는 전 미션에서 OAuth2AccessTokenRequestProvider 로 이미 구조를 잡아놔서 해당 클래스를 갖다 썼습니다.

그리고 인가서버에서 받아오는 에러는 인가 에러라고 판단해서 403 을 던지게 만들었는데 이게 맞는 건지? 
궁금합니다.